### PR TITLE
fix deprecated cloning resource attrs for services (CHEF-3694)

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -103,24 +103,29 @@ end
 case node['nut']['mode']
 
 when 'netserver'
-  service 'nut-client' do
+  service 'client' do
+    service_name 'nut-client'
     action [:enable, :start]
     not_if { node['nut']['monitors'].nil? }
   end
-  service 'nut-server' do
+  service 'server' do
+    service_name 'nut-server'
     action [:enable, :start]
   end
 
 when 'netclient'
-  service 'nut-client' do
+  service 'client' do
+    service_name 'nut-client'
     action [:enable, :start]
   end
 
 when 'standalone'
-  service 'nut-client' do
+  service 'client' do
+    service_name 'nut-client'
     action [:enable, :start]
   end
-  service 'nut-server' do
+  service 'server' do
+    service_name 'nut-server'
     action [:enable, :start]
   end
 end


### PR DESCRIPTION
Despite @tas50 very good job.

chef-client (12.13.37) still puts warning like:

```
Deprecated features used!
  Cloning resource attributes for service[nut-client] from prior resource (CHEF-3694)
Previous service[nut-client]: /var/chef/cache/cookbooks/nut/recipes/default.rb:35:in `from_file'
Current  service[nut-client]: /var/chef/cache/cookbooks/nut/recipes/default.rb:115:in `from_file' at 1 location:
    - /var/chef/cache/cookbooks/nut/recipes/default.rb:115:in `from_file'
```

After some googling i found a joshua timberman post about how to solve this issue.

It is a simplest workaround for it.

Please merge if you think so.