### PR TITLE
fix deprecated cloning resource attrs for services (CHEF-3694)

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -103,29 +103,72 @@ end
 case node['nut']['mode']
 
 when 'netserver'
-  service 'client' do
-    service_name 'nut-client'
-    action [:enable, :start]
-    not_if { node['nut']['monitors'].nil? }
-  end
-  service 'server' do
-    service_name 'nut-server'
-    action [:enable, :start]
+
+  control_group 'netserver' do
+    control 'netserver' do
+
+      # nut-client
+      it 'should be enabled' do
+          expect(service('nut-client')).to be_enabled
+          not_if { node['nut']['monitors'].nil? }
+      end
+  
+      it 'should be running' do
+        expect(service('nut-client')).to be_running
+      end
+
+      # nut-server
+      it 'should be enabled' do
+          expect(service('nut-server')).to be_enabled
+      end
+
+      it 'should be running' do
+        expect(service('nut-server')).to be_running
+      end
+
+    end
   end
 
+
 when 'netclient'
-  service 'client' do
-    service_name 'nut-client'
-    action [:enable, :start]
+
+  control_group 'netclient' do
+    control 'netclient' do
+
+      # nut-client
+      it 'should be enabled' do
+          expect(service('nut-client')).to be_enabled
+      end
+
+      it 'should be running' do
+        expect(service('nut-client')).to be_running
+      end
+
+    end
   end
 
 when 'standalone'
-  service 'client' do
-    service_name 'nut-client'
-    action [:enable, :start]
+
+  control_group 'standalone' do
+    control 'standalone' do
+
+      # nut-client
+      it 'should be enabled' do
+          expect(service('nut-client')).to be_enabled
+      end
+      it 'should be running' do
+        expect(service('nut-client')).to be_running
+      end
+
+      # nut-server
+      it 'should be enabled' do
+          expect(service('nut-server')).to be_enabled
+      end
+      it 'should be running' do
+        expect(service('nut-server')).to be_running
+      end
+
+    end
   end
-  service 'server' do
-    service_name 'nut-server'
-    action [:enable, :start]
-  end
+
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -103,24 +103,29 @@ end
 case node['nut']['mode']
 
 when 'netserver'
-  service 'nut-client' do
+  service 'client' do
+    service_name 'nut-client'
     action [:enable, :start]
     not_if { node['nut']['monitors'].nil? }
   end
-  service 'nut-server' do
+  service 'server' do
+    service_name 'nut-server'
     action [:enable, :start]
   end
 
 when 'netclient'
-  service 'nut-client' do
+  service 'client' do
+    service_name 'nut-client'
     action [:enable, :start]
   end
 
 when 'standalone'
-  service 'nut-client' do
+  service 'client' do
+    service_name 'nut-client'
     action [:enable, :start]
   end
-  service 'nut-server' do
+  service 'server' do
+    service_name 'nut-server'
     action [:enable, :start]
   end
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -104,28 +104,48 @@ case node['nut']['mode']
 
 when 'netserver'
   service 'client' do
-    service_name 'nut-client'
+    if node['platform_version'].to_f >= 14.04
+      service_name 'nut-client'
+    else
+      service_name 'nut'
+    end
     action [:enable, :start]
     not_if { node['nut']['monitors'].nil? }
   end
   service 'server' do
-    service_name 'nut-server'
+    if node['platform_version'].to_f >= 14.04
+      service_name 'nut-server'
+    else
+      service_name 'nut'
+    end
     action [:enable, :start]
   end
 
 when 'netclient'
   service 'client' do
-    service_name 'nut-client'
+    if node['platform_version'].to_f >= 14.04
+      service_name 'nut-client'
+    else
+      service_name 'nut'
+    end
     action [:enable, :start]
   end
 
 when 'standalone'
   service 'client' do
-    service_name 'nut-client'
+    if node['platform_version'].to_f >= 14.04
+      service_name 'nut-client'
+    else
+      service_name 'nut'
+    end
     action [:enable, :start]
   end
   service 'server' do
-    service_name 'nut-server'
+    if node['platform_version'].to_f >= 14.04
+      service_name 'nut-server'
+    else
+      service_name 'nut'
+    end
     action [:enable, :start]
   end
 end


### PR DESCRIPTION
Despite @tas50 very good job.

chef-client (12.13.37) still puts warning like:

```
Deprecated features used!
  Cloning resource attributes for service[nut-client] from prior resource (CHEF-3694)
Previous service[nut-client]: /var/chef/cache/cookbooks/nut/recipes/default.rb:35:in `from_file'
Current  service[nut-client]: /var/chef/cache/cookbooks/nut/recipes/default.rb:115:in `from_file' at 1 location:
    - /var/chef/cache/cookbooks/nut/recipes/default.rb:115:in `from_file'
```

It is a simplest workaround for it.

Please merge if you think so.

Changes tested in 12.04 and 14.04.
